### PR TITLE
Allow per deployment override of mem, disk and services

### DIFF
--- a/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
@@ -21,11 +21,19 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.constraints.NotBlank;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 
 /**
+ * Configuration properties to determine how to connect to Cloud Foundry, and some
+ * defaults for module deployment.
+ *
  * @author Eric Bottard
  */
 @ConfigurationProperties("cloudfoundry")
@@ -90,7 +98,7 @@ class CloudFoundryModuleDeployerProperties {
 	/**
 	 * The amount of disk space (MB) to allocate, if not overridden per-module.
 	 */
-	private int disk;
+	private int disk = 1024;
 
 	public String getPassword() {
 		return password;
@@ -108,6 +116,7 @@ class CloudFoundryModuleDeployerProperties {
 		this.username = username;
 	}
 
+	@NotNull
 	public URL getApiEndpoint() {
 		return apiEndpoint;
 	}
@@ -140,6 +149,7 @@ class CloudFoundryModuleDeployerProperties {
 		this.organization = organization;
 	}
 
+	@NotBlank
 	public String getSpace() {
 		return space;
 	}
@@ -156,6 +166,7 @@ class CloudFoundryModuleDeployerProperties {
 		this.skipSslValidation = skipSslValidation;
 	}
 
+	@NotNull
 	public Resource getModuleLauncherLocation() {
 		return moduleLauncherLocation;
 	}
@@ -172,6 +183,7 @@ class CloudFoundryModuleDeployerProperties {
 		this.buildpack = buildpack;
 	}
 
+	@Min(0)
 	public int getMemory() {
 		return memory;
 	}
@@ -180,6 +192,7 @@ class CloudFoundryModuleDeployerProperties {
 		this.memory = memory;
 	}
 
+	@Min(0)
 	public int getDisk() {
 		return disk;
 	}

--- a/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
@@ -32,7 +32,7 @@ import org.springframework.core.io.Resource;
 class CloudFoundryModuleDeployerProperties {
 
 	/**
-	 * The names of services to bind to each application deployed as a module.
+	 * The names of services to bind to all applications deployed as a module.
 	 * This should typically contain a service capable of playing the role of a binding transport.
 	 */
 	private Set<String> services = new HashSet<>(Arrays.asList("redis"));
@@ -81,6 +81,16 @@ class CloudFoundryModuleDeployerProperties {
 	 * The buildpack to use for deploying the application.
 	 */
 	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git#master";
+
+	/**
+	 * The amount of memory (MB) to allocate, if not overridden per-module.
+	 */
+	private int memory = 1024;
+
+	/**
+	 * The amount of disk space (MB) to allocate, if not overridden per-module.
+	 */
+	private int disk;
 
 	public String getPassword() {
 		return password;
@@ -160,5 +170,21 @@ class CloudFoundryModuleDeployerProperties {
 
 	public void setBuildpack(String buildpack) {
 		this.buildpack = buildpack;
+	}
+
+	public int getMemory() {
+		return memory;
+	}
+
+	public void setMemory(int memory) {
+		this.memory = memory;
+	}
+
+	public int getDisk() {
+		return disk;
+	}
+
+	public void setDisk(int disk) {
+		this.disk = disk;
 	}
 }


### PR DESCRIPTION
fixes spring-cloud/spring-cloud-dataflow-admin-cloudfoundry#7

For example, to bind the `redis2` service to the `log` module, in addition to the `redis` service that would be bound to all modules, one would do:

```
stream create foobaba --definition "time | log"

stream deploy foobaba --properties "module.log.cloudfoundry.services=redis2"
```