### PR TITLE
Replace Kubernetes reference with Cloud Foundry.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Spring Cloud Data Flow Admin for Cloud Foundry image:https://build.spring.io/plugins/servlet/buildStatusImage/SCD-CFBMASTER[Build Status, link=https://build.spring.io/browse/SCD-CFBMASTER] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-admin-cloudfoundry.svg?label=ready&title=Ready[Stories in Ready, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-admin-cloudfoundry] image:https://badge.waffle.io/spring-cloud/spring-cloud-dataflow-admin-cloudfoundry.svg?label=In%20Progress&title=In%20Progress[Stories in Progress, link=http://waffle.io/spring-cloud/spring-cloud-dataflow-admin-cloudfoundry]
 
-This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Dataflow] Stream definitions to Cloud Foundry.  It includes an implementation of the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-module-deployer-spi[Spring Cloud Stream Module Deployer SPI] for Kubernetes.
+This project provides support for deploying https://github.com/spring-cloud/spring-cloud-dataflow[Spring Cloud Dataflow] Stream definitions to Cloud Foundry.  It includes an implementation of the https://github.com/spring-cloud/spring-cloud-dataflow/tree/master/spring-cloud-dataflow-module-deployer-spi[Spring Cloud Stream Module Deployer SPI] for Cloud Foundry.
 
 Please refer to the http://docs.spring.io/spring-cloud-dataflow-admin-cloudfoundry/docs/current-SNAPSHOT/reference/htmlsingle/#getting-started[reference documentation] on how to get started.
 


### PR DESCRIPTION
I am not sure that a project targeted to Cloud Foundry has any relation with Kubernetes. More specifically that the SPI is of Kubernetes and not Cloud Foundry.