### PR TITLE
enabling the configuration to work as a Spring Boot auto-configuration

### DIFF
--- a/spring-cloud-dataflow-admin-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-admin-cloudfoundry/pom.xml
@@ -54,6 +54,7 @@
 				<filtering>true</filtering>
 				<includes>
 					<include>admin.yml</include>
+					<include>META-INF/spring.factories</include>
 					<include>banner.txt</include>
 				</includes>
 			</resource>

--- a/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/admin/spi/cloudfoundry/CloudFoundryAutoConfiguration.java
+++ b/spring-cloud-dataflow-admin-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/admin/spi/cloudfoundry/CloudFoundryAutoConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
  */
 @Configuration
 @Import(CloudFoundryModuleDeployerConfiguration.class)
-public class CloudFoundryConfiguration {
+public class CloudFoundryAutoConfiguration {
 
 	@Profile("cloud")
 	@AutoConfigureBefore(RedisAutoConfiguration.class)

--- a/spring-cloud-dataflow-admin-cloudfoundry/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-admin-cloudfoundry/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.springframework.cloud.dataflow.admin.spi.cloudfoundry.CloudFoundryAutoConfiguration


### PR DESCRIPTION
if this is on the CLASSPATH of the Spring Cloud Dataflow Admin it'll be picked up and integrate with it automatically.

This resolves spring-cloud/spring-cloud-dataflow-admin-cloudfoundry#32