### PR TITLE
Remove `server-core` dependency from cf server starter

### DIFF
--- a/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
@@ -20,9 +20,5 @@
 			<artifactId>spring-cloud-dataflow-deployer-cloudfoundry</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dataflow-server-core</artifactId>
-		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
 - Since the `s-c-d-deployer-cf` already depends on `s-c-d-server-core`, we can remove it from the starter dependencies