### PR TITLE
Update to app-launcher

### DIFF
--- a/spring-cloud-dataflow-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
@@ -63,7 +63,7 @@ class CloudFoundryModuleDeployerProperties {
 	/**
 	 * Location of the ModuleLauncher uber-jar to be uploaded.
 	 */
-	private Resource moduleLauncherLocation = new ClassPathResource("spring-cloud-stream-module-launcher.jar");
+	private Resource moduleLauncherLocation = new ClassPathResource("spring-cloud-dataflow-app-launcher.jar");
 
 	/**
 	 * Location of the CloudFoundry REST API endpoint to use.

--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -50,7 +50,7 @@
 							<artifactItems>
 								<artifactItem>
 									<groupId>org.springframework.cloud</groupId>
-									<artifactId>spring-cloud-stream-module-launcher</artifactId>
+									<artifactId>spring-cloud-dataflow-app-launcher</artifactId>
 								</artifactItem>
 							</artifactItems>
 							<stripVersion>true</stripVersion>


### PR DESCRIPTION
Update references from the Spring Cloud Stream Module Launcher to the replacement Spring Cloud Data Flow App Launcher

To be merged after #23 and #55 are merged. In the mean time the old snapshot module launcher build will be used.