### PR TITLE
Set buildpack version to last known good one

### DIFF
--- a/spring-cloud-dataflow-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
+++ b/spring-cloud-dataflow-deployer-cloudfoundry/src/main/java/org/springframework/cloud/dataflow/module/deployer/cloudfoundry/CloudFoundryModuleDeployerProperties.java
@@ -88,7 +88,7 @@ class CloudFoundryModuleDeployerProperties {
 	/**
 	 * The buildpack to use for deploying the application.
 	 */
-	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git#master";
+	private String buildpack = "https://github.com/cloudfoundry/java-buildpack.git#v3.6";
 
 	/**
 	 * The amount of memory (MB) to allocate, if not overridden per-module.


### PR DESCRIPTION
- prevents deployment failures where `cloud` is not set as the profile

Fixes #65