### PR TITLE
Use correct reactor version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 	<properties>
 		<spring-cloud-dataflow.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-dataflow.version>
 		<spring-cloud-cloudfoundry-deployer.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-cloudfoundry-deployer.version>
-		<reactor.version>2.5.0.M2</reactor.version>
+		<reactor.version>2.5.0.BUILD-SNAPSHOT</reactor.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-dataflow-server-cloudfoundry/pom.xml
@@ -35,11 +35,11 @@
 	<dependencyManagement>
 		<dependencies>
 			<!-- (re)Force reactor version -->
-			<dependency>
-				<groupId>io.projectreactor</groupId>
-				<artifactId>reactor-core</artifactId>
-				<version>${reactor.version}</version>
-			</dependency>
+			<!--<dependency>-->
+				<!--<groupId>io.projectreactor</groupId>-->
+				<!--<artifactId>reactor-core</artifactId>-->
+				<!--<version>${reactor.version}</version>-->
+			<!--</dependency>-->
 		</dependencies>
 	</dependencyManagement>
 	<build>

--- a/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-dataflow-server-cloudfoundry/pom.xml
@@ -17,11 +17,11 @@
 	<dependencyManagement>
 		<dependencies>
 			<!-- (re)Force reactor version -->
-			<dependency>
-				<groupId>io.projectreactor</groupId>
-				<artifactId>reactor-core</artifactId>
-				<version>${reactor.version}</version>
-			</dependency>
+			<!--<dependency>-->
+				<!--<groupId>io.projectreactor</groupId>-->
+				<!--<artifactId>reactor-core</artifactId>-->
+				<!--<version>${reactor.version}</version>-->
+			<!--</dependency>-->
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>


### PR DESCRIPTION
This fixes spring-cloud/spring-cloud-dataflow-admin-cloudfoundry#79

Sadly, this is the only way (managed to get rid of the redundant depMgmt section),
but because ${reactor.version} is what is used but also declared by one of
our parents pom, we'll need to override ad vitam.